### PR TITLE
XLink Kai 7.4.32-rev755 executable filename change

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -47,12 +47,12 @@ chmod 755 /home/pi/setup-wifi-access-point.sh
 # Install Xlink Kai
 wget https://cdn.teamxlink.co.uk/binary/kaiEngine-7.4.32-rev755.headless.ARM.tar.gz
 tar -xzvf kaiEngine-7.4.32-rev755.headless.ARM.tar.gz
-sudo cp kaiEngine-7.4.32/kaiengine /usr/local/bin
+sudo cp kaiEngine-7.4.32/kaiengine_arm /usr/local/bin
 sudo mkdir /root/.xlink
 
 cat <<'EOF' > /home/pi/launchkai.sh
 while true; do
-    /usr/local/bin/kaiengine
+    /usr/local/bin/kaiengine_arm
     sleep 1
 done
 EOF


### PR DESCRIPTION
TeamXLink changed the executable filename from 'kaiengine' to 'kaiengine_arm'. Updated script to reflect this for copy to bin line and executable line for launchkai.sh