### PR TITLE
fix: opl smb error 301

### DIFF
--- a/automount-usb.sh
+++ b/automount-usb.sh
@@ -75,6 +75,7 @@ pkill ps3netsrv++
 #create a new smb share for the mounted drive
 cat <<EOS | sudo tee /etc/samba/smb.conf
 [global]
+server min protocol = NT1
 workgroup = WORKGROUP
 usershare allow guests = yes
 map to guest = bad user

--- a/samba-init.sh
+++ b/samba-init.sh
@@ -14,6 +14,7 @@ pkill ps3netsrv++
 
 sudo cat <<'EOF' | sudo tee /etc/samba/smb.conf
 [global]
+server min protocol = NT1
 workgroup = WORKGROUP
 usershare allow guests = yes
 map to guest = bad user


### PR DESCRIPTION
Couldn't connect to smb in opl with most recent raspiOS `(2022-01-28-raspios-bullseye-arm64-lite)`. Tracked it down to an issue with protocol negotiation `Requested protocol [NT LM 0.12]  Server exit (no protocol supported)`.

Fixed by adding `server min protocol` to the smb.conf.