### PR TITLE
setup.sh: add kailauncher to the background

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -83,7 +83,7 @@ sudo /usr/local/bin/samba-init.sh
 sudo /home/pi/wifi-to-eth-route.sh
 sudo /home/pi/setup-wifi-access-point.sh
 ps3netsrv++ -d /share/
-/home/pi/launchkai.sh
+screen -dmS kailauncher /home/pi/launchkai.sh
 
 # Not a bad idea to reboot
 sudo reboot


### PR DESCRIPTION
Moving the launch script of XLink Kai to the background should fix #50 #60 and #41 from associated installation errors in my testing.

Edit: The release of Kaiengine 7.4.44 should address #41 in our testing.