### PR TITLE
User options and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The following commands can be used to upgrade an existing psx-pi-smbshare device
 cd ~
 wget -O setup.sh https://raw.githubusercontent.com/toolboc/psx-pi-smbshare/master/setup.sh
 chmod 755 setup.sh
-sudo ./setup.sh
+./setup.sh
 ```
 
 ## How it works
@@ -124,7 +124,7 @@ This configuration will forward all ftp requests made to the host ip of the psx-
             IP Address = 192.168.2.2
             Subnet Mask = 255.255.255.0
             Default Router = 192.168.2.1
-            Primary DNS = 8.8.8.8
+            Primary DNS = 1.1.1.1
             Secondary DNS = <leave blank or use your home router ip address>
 
     "Automatic" => "Do Not Use" => "Enable"
@@ -153,7 +153,7 @@ Ensure that the following options are set:
             IP address = 192.168.2.2
             Mask = 255.255.255.0
             Gateway = 192.168.2.1
-            DNS Server = 8.8.8.8
+            DNS Server = 1.1.1.1
         SMB Server
             Address Type = IP
             Address = 192.168.2.1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can see it in action in this video from [@versatileninja](https://github.com
 The following commands can be used to upgrade an existing psx-pi-smbshare device.  These instructions can also be used to convert an unsupported device into a psx-pi-smbshare (for example [Raspberry Pi4](https://github.com/toolboc/psx-pi-smbshare/issues/10) and potentially other devices running a debian based OS with an accessible ethernet port).
 ```
 cd ~
-wget -O setup.sh https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/setup.sh
+wget -O setup.sh https://raw.githubusercontent.com/toolboc/psx-pi-smbshare/master/setup.sh
 chmod 755 setup.sh
 ./setup.sh
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can see it in action in this video from [@versatileninja](https://github.com
 The following commands can be used to upgrade an existing psx-pi-smbshare device.  These instructions can also be used to convert an unsupported device into a psx-pi-smbshare (for example [Raspberry Pi4](https://github.com/toolboc/psx-pi-smbshare/issues/10) and potentially other devices running a debian based OS with an accessible ethernet port).
 ```
 cd ~
-wget -O setup.sh https://raw.githubusercontent.com/toolboc/psx-pi-smbshare/master/setup.sh
+wget -O setup.sh https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/setup.sh
 chmod 755 setup.sh
 ./setup.sh
 ```

--- a/automount-usb.sh
+++ b/automount-usb.sh
@@ -20,6 +20,10 @@ sudo apt-get install -y ntfs-3g udisks2
 sudo usermod -a -G disk ${USER}
 
 # Create polkit rule
+sudo mkdir -p /etc/polkit-1/rules.d/
+sudo mkdir -p /etc/polkit-1/localauthority/50-local.d/
+
+# For polkit > 105
 sudo cat <<'EOF' | sudo tee /etc/polkit-1/rules.d/10-udisks2.rules
 // Allow udisks2 to mount devices without authentication
 // for users in the "disk" group.
@@ -31,6 +35,16 @@ polkit.addRule(function(action, subject) {
         return polkit.Result.YES;
     }
 });
+EOF
+
+# For polkit <= 105
+sudo cat <<'EOF' | sudo tee /etc/polkit-1/localauthority/50-local.d/10-udisks2.pkla
+[Authorize mounting of devices for group disk]
+Identity=unix-group:disk
+Action=org.freedesktop.udisks2.filesystem-mount-system;org.freedesktop.udisks2.filesystem-mount;org.freedesktop.udisks2.filesystem-mount-other-seat
+ResultAny=yes
+ResultInactive=yes
+ResultActive=yes
 EOF
 
 # Create udev rule

--- a/automount-usb.sh
+++ b/automount-usb.sh
@@ -118,4 +118,4 @@ sudo sed -i "s/userplaceholder/${USER}/g" /usr/local/bin/automount.sh
 sudo chmod +x /usr/local/bin/automount.sh
 
 # Reload udev rules and triggers
-sudo udevadm control --reload-rules && udevadm trigger
+sudo udevadm control --reload-rules && sudo udevadm trigger

--- a/samba-init.sh
+++ b/samba-init.sh
@@ -8,9 +8,12 @@ then
     exit
 fi
 
-#restart ps3netsrv++
-pkill ps3netsrv++
-/usr/local/bin/ps3netsrv++ -d /share
+#if /usr/local/bin/ps3netsrv++ exists
+if [ -f /usr/local/bin/ps3netsrv++ ]; then
+  #restart ps3netsrv++
+  pkill ps3netsrv++
+  /usr/local/bin/ps3netsrv++ -d /share
+fi
 
 sudo cat <<'EOF' | sudo tee /etc/samba/smb.conf
 [global]
@@ -20,7 +23,7 @@ usershare allow guests = yes
 map to guest = bad user
 allow insecure wide links = yes
 [share]
-Comment = Pi shared folder
+Comment = shared folder
 Path = /share
 Browseable = yes
 Writeable = Yes
@@ -29,11 +32,11 @@ create mask = 0777
 directory mask = 0777
 Public = yes
 Guest ok = yes
-force user = pi
+force user = userplaceholder
 follow symlinks = yes
 wide links = yes
 EOF
 
 #if you wish to create a samba user with password you can use the following:
-#sudo smbpasswd -a pi
+#sudo smbpasswd -a userplaceholder
 sudo /etc/init.d/smbd restart

--- a/setup.sh
+++ b/setup.sh
@@ -42,6 +42,12 @@ else
   WIFIACCESSPOINT=false
 fi
 
+if whiptail --yesno "Would you like to share wifi over ethernet, for devices without wifi? (Ethernet will no longer work for providing the pi an internet connection)" 9 55; then
+  ETHROUTE=true
+else
+  ETHROUTE=false
+fi
+
 # Update packages
 sudo apt-get -y update
 sudo apt-get -y upgrade
@@ -68,9 +74,12 @@ if [ "$PS3NETSRV" = true ]; then
   sudo cp ps3netsrv++ /usr/local/bin
 fi
 
-# Install wifi-to-eth route settings
-sudo apt-get install -y dnsmasq
-wget https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/wifi-to-eth-route.sh -O /home/${USER}/wifi-to-eth-route.sh
+if [ "$ETHROUTE" = true ]; then
+  # Install wifi-to-eth route settings
+  sudo apt-get install -y dnsmasq
+  wget https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/wifi-to-eth-route.sh -O /home/${USER}/wifi-to-eth-route.sh
+else
+  touch /home/${USER}/wifi-to-eth-route.sh
 chmod 755 /home/${USER}/wifi-to-eth-route.sh
 
 if [ "$WIFIACCESSPOINT" = true ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -24,38 +24,66 @@ if [ $USER = "root" ]; then
   exit 1
 fi
 
+if whiptail --yesno "Would you like to enable ps3netsrv for PS3 support? (SMB is enabled either way for PS2 support etc.)" 8 55; then
+  PS3NETSRV=true
+else
+  PS3NETSRV=false
+fi
+
+if whiptail --yesno "Would you like to enable XLink Kai?" 8 55; then
+  XLINKKAI=true
+else
+  XLINKKAI=false
+fi
+
+if whiptail --yesno "Would you like to enable wifi access point for a direct wifi connection?" 8 55; then
+  WIFIACCESSPOINT=true
+else
+  WIFIACCESSPOINT=false
+fi
+
 # Update packages
 sudo apt-get -y update
 sudo apt-get -y upgrade
 
 # Ensure basic tools are present
-sudo apt-get -y install screen wget git curl coreutils
+sudo apt-get -y install screen wget git curl coreutils iptables hostapd
 
 # Install and configure Samba
 sudo apt-get install -y samba samba-common-bin
-wget https://raw.githubusercontent.com/toolboc/psx-pi-smbshare/master/samba-init.sh -O /home/${USER}/samba-init.sh
+wget https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/samba-init.sh -O /home/${USER}/samba-init.sh
+sed -i "s/userplaceholder/${USER}/g" /home/${USER}/samba-init.sh
 chmod 755 /home/${USER}/samba-init.sh
 sudo cp /home/${USER}/samba-init.sh /usr/local/bin
 sudo mkdir -m 1777 /share
 
-# Install ps3netsrv
-sudo rm /usr/local/bin/ps3netsrv++
-sudo apt-get install -y git gcc
-git clone https://github.com/dirkvdb/ps3netsrv--.git
-cd ps3netsrv--
-git submodule update --init
-make CXX=g++
-sudo cp ps3netsrv++ /usr/local/bin
+# Install ps3netsrv if PS3NETSRV is true
+if [ "$PS3NETSRV" = true ]; then
+  sudo rm /usr/local/bin/ps3netsrv++
+  sudo apt-get install -y git gcc
+  git clone https://github.com/dirkvdb/ps3netsrv--.git
+  cd ps3netsrv--
+  git submodule update --init
+  make CXX=g++
+  sudo cp ps3netsrv++ /usr/local/bin
+fi
 
 # Install wifi-to-eth route settings
 sudo apt-get install -y dnsmasq
-wget https://raw.githubusercontent.com/toolboc/psx-pi-smbshare/master/wifi-to-eth-route.sh -O /home/${USER}/wifi-to-eth-route.sh
+wget https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/wifi-to-eth-route.sh -O /home/${USER}/wifi-to-eth-route.sh
 chmod 755 /home/${USER}/wifi-to-eth-route.sh
 
-# Install setup-wifi-access-point settings
-sudo apt-get install -y hostapd bridge-utils
-wget https://raw.githubusercontent.com/toolboc/psx-pi-smbshare/master/setup-wifi-access-point.sh -O /home/${USER}/setup-wifi-access-point.sh
+if [ "$WIFIACCESSPOINT" = true ]; then
+  # Install setup-wifi-access-point settings
+  sudo apt-get install -y hostapd bridge-utils
+  wget https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/setup-wifi-access-point.sh -O /home/${USER}/setup-wifi-access-point.sh
+else
+  touch /home/${USER}/setup-wifi-access-point.sh
+fi
 chmod 755 /home/${USER}/setup-wifi-access-point.sh
+
+# Install XLink Kai if XLINKKAI is true
+if [ "$XLINKKAI" = true ]; then
 
 # Remove old XLink Kai Repo if present
 sudo rm -rf /etc/apt/sources.list.d/teamxlink.list
@@ -81,23 +109,20 @@ while true; do
     sleep 5
 done
 EOF
+else
+touch /home/${USER}/launchkai.sh
 
+#End of XLink Kai install
+fi
 chmod 755 /home/${USER}/launchkai.sh
 
 # Install USB automount settings
-wget https://raw.githubusercontent.com/toolboc/psx-pi-smbshare/master/automount-usb.sh -O /home/${USER}/automount-usb.sh
+wget https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/automount-usb.sh -O /home/${USER}/automount-usb.sh
 chmod 755 /home/${USER}/automount-usb.sh
-sudo /home/${USER}/automount-usb.sh
+/home/${USER}/automount-usb.sh
 
 # Set samba-init + ps3netsrv, wifi-to-eth-route, setup-wifi-access-point, and XLink Kai to run on startup
-{ echo -e "@reboot sudo bash /usr/local/bin/samba-init.sh\n@reboot sudo bash /home/${USER}/wifi-to-eth-route.sh && sudo bash /home/${USER}/setup-wifi-access-point.sh\n@reboot bash /home/${USER}/launchkai.sh"; } | crontab -u pi -
-
-# Start services
-sudo /usr/local/bin/samba-init.sh
-sudo /home/${USER}/wifi-to-eth-route.sh
-sudo /home/${USER}/setup-wifi-access-point.sh
-ps3netsrv++ -d /share/
-screen -dmS kailauncher /home/${USER}/launchkai.sh
+{ echo -e "@reboot sudo bash /usr/local/bin/samba-init.sh\n@reboot sudo bash /home/${USER}/wifi-to-eth-route.sh && sudo bash /home/${USER}/setup-wifi-access-point.sh\n@reboot bash /home/${USER}/launchkai.sh"; } | crontab -u ${USER} -
 
 # Not a bad idea to reboot
 sudo reboot

--- a/setup.sh
+++ b/setup.sh
@@ -80,6 +80,7 @@ if [ "$ETHROUTE" = true ]; then
   wget https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/wifi-to-eth-route.sh -O /home/${USER}/wifi-to-eth-route.sh
 else
   touch /home/${USER}/wifi-to-eth-route.sh
+fi
 chmod 755 /home/${USER}/wifi-to-eth-route.sh
 
 if [ "$WIFIACCESSPOINT" = true ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -57,7 +57,7 @@ sudo apt-get -y install screen wget git curl coreutils iptables hostapd
 
 # Install and configure Samba
 sudo apt-get install -y samba samba-common-bin
-wget https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/samba-init.sh -O /home/${USER}/samba-init.sh
+wget https://raw.githubusercontent.com/toolboc/psx-pi-smbshare/master/samba-init.sh -O /home/${USER}/samba-init.sh
 sed -i "s/userplaceholder/${USER}/g" /home/${USER}/samba-init.sh
 chmod 755 /home/${USER}/samba-init.sh
 sudo cp /home/${USER}/samba-init.sh /usr/local/bin
@@ -77,7 +77,7 @@ fi
 if [ "$ETHROUTE" = true ]; then
   # Install wifi-to-eth route settings
   sudo apt-get install -y dnsmasq
-  wget https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/wifi-to-eth-route.sh -O /home/${USER}/wifi-to-eth-route.sh
+  wget https://raw.githubusercontent.com/toolboc/psx-pi-smbshare/master/wifi-to-eth-route.sh -O /home/${USER}/wifi-to-eth-route.sh
 else
   touch /home/${USER}/wifi-to-eth-route.sh
 fi
@@ -86,7 +86,7 @@ chmod 755 /home/${USER}/wifi-to-eth-route.sh
 if [ "$WIFIACCESSPOINT" = true ]; then
   # Install setup-wifi-access-point settings
   sudo apt-get install -y hostapd bridge-utils
-  wget https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/setup-wifi-access-point.sh -O /home/${USER}/setup-wifi-access-point.sh
+  wget https://raw.githubusercontent.com/toolboc/psx-pi-smbshare/master/setup-wifi-access-point.sh -O /home/${USER}/setup-wifi-access-point.sh
 else
   touch /home/${USER}/setup-wifi-access-point.sh
 fi
@@ -127,7 +127,7 @@ fi
 chmod 755 /home/${USER}/launchkai.sh
 
 # Install USB automount settings
-wget https://raw.githubusercontent.com/georgewoodall82/psx-pi-smbshare-updated/master/automount-usb.sh -O /home/${USER}/automount-usb.sh
+wget https://raw.githubusercontent.com/toolboc/psx-pi-smbshare/master/automount-usb.sh -O /home/${USER}/automount-usb.sh
 chmod 755 /home/${USER}/automount-usb.sh
 /home/${USER}/automount-usb.sh
 

--- a/wifi-to-eth-route.sh
+++ b/wifi-to-eth-route.sh
@@ -41,7 +41,7 @@ sudo rm -rf /etc/dnsmasq.d/*
 
 echo -e "interface=$eth\n\
 bind-dynamic\n\
-server=8.8.8.8\n\
+server=1.1.1.1\n\
 domain-needed\n\
 bogus-priv\n\
 dhcp-range=$dhcp_range_start,$dhcp_range_end,$dhcp_time" > /etc/dnsmasq.d/custom-dnsmasq.conf


### PR DESCRIPTION
* Replaced pmount with udisks2, as pmount is very old, and for me, it would only mount NTFS drives. Switching to udisks2 also gave me a very huge transfer speed boost over pmount.
* Added multiple options for the user to choose when running setup.sh, to free a lot of resources and speed up the install.
* Replaced the DNS 8.8.8.8 (Google) with 1.1.1.1 (Cloudflare) for increased privacy and lower latency.
* No longer assumes that the user is pi, instead auto-detecting it. (Another user tried to do this before, but did a terrible job)
* Removed sudo from install script, as doing so gave an error.